### PR TITLE
Dereference /var/run symbolic links

### DIFF
--- a/authoritative/Dockerfile
+++ b/authoritative/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=builder /usr/share/man/man1 /usr/share/man/man1/
 COPY --from=builder /usr/local/share/doc/pdns /usr/local/share/doc/pdns
 COPY --from=builder /etc/pdns /etc/pdns/
 
-RUN install -v -d -m 00770 -o root -g pdns /var/run/pdns && ls -l /var/run
+RUN install -v -d -m 00770 -o root -g pdns /var/run/pdns && ls -l /var/run/
 
 RUN cp -p /etc/pdns/pdns.conf-dist /etc/pdns/pdns.conf && \
     /usr/local/sbin/pdns_server --version || [ $? -eq 99 ]

--- a/recursor/Dockerfile
+++ b/recursor/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=builder /usr/local/sbin /usr/local/sbin/
 COPY --from=builder /usr/share/man/man1 /usr/share/man/man1/
 COPY --from=builder /etc/pdns-recursor /etc/pdns-recursor/
 
-RUN install -v -d -m 00770 -o root -g pdns-recursor /var/run/pdns-recursor && ls -l /var/run
+RUN install -v -d -m 00770 -o root -g pdns-recursor /var/run/pdns-recursor && ls -l /var/run/
 
 RUN cp -p /etc/pdns-recursor/recursor.conf-dist /etc/pdns-recursor/recursor.conf && \
     /usr/local/sbin/pdns_recursor --version


### PR DESCRIPTION
Alpine Linux links from `/var/run` to `/run`, but we care about the contents not the link.