### PR TITLE
Enable DNS over HTTPS support (dnsdist) + other misc. stuff

### DIFF
--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -45,7 +45,7 @@ RUN addgroup -g 1000 -S dnsdist && \
 COPY --from=builder /usr/local/bin /usr/local/bin/
 COPY --from=builder /usr/share/man/man1 /usr/share/man/man1/
 
-RUN /usr/local/bin/dnsdist --version
+RUN dnsdist --version
 
-ENTRYPOINT ["/usr/local/bin/dnsdist"]
+ENTRYPOINT ["dnsdist"]
 CMD ["--help"]

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine AS builder
+FROM alpine:3 AS builder
 
 ARG DNSDIST_VERSION
 
@@ -28,7 +28,7 @@ RUN apk --update upgrade && \
     ) && \
     apk del --purge .build-depends && rm -rf /var/cache/apk/*
 
-FROM alpine
+FROM alpine:3
 LABEL maintainer="https://keybase.io/tcely"
 
 RUN apk --update upgrade && \

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -10,9 +10,9 @@ RUN apk upgrade --no-cache && \
         libedit-dev re2-dev h2o-dev && \
     [ -n "$DNSDIST_VERSION" ] || { curl -sSL 'https://api.github.com/repos/PowerDNS/pdns/tags?per_page=100&page={1,2,3}' | jq -rs '[.[][]]|map(select(has("name")))|map(select(.name|contains("dnsdist-")))|map(.version=(.name|ltrimstr("dnsdist-")))|map(select(true != (.version|contains("-"))))|map(.version)|"DNSDIST_VERSION="+.[0]' > /tmp/latest-dnsdist-tag.sh && . /tmp/latest-dnsdist-tag.sh; } && \
     mkdir -v -m 0700 -p /root/.gnupg && \
-    curl -RL -O 'https://dnsdist.org/_static/dnsdist-keyblock.asc' && \
+    curl -sSRL -O 'https://dnsdist.org/_static/dnsdist-keyblock.asc' && \
     gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true --import *.asc && \
-    curl -RL -O "https://downloads.powerdns.com/releases/dnsdist-${DNSDIST_VERSION}.tar.bz2{.asc,.sig,}" && \
+    curl -sSRL -O "https://downloads.powerdns.com/releases/dnsdist-${DNSDIST_VERSION}.tar.bz2{.asc,.sig,}" && \
     gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true --verify *.sig && \
     tar -xpf "dnsdist-${DNSDIST_VERSION}.tar.bz2" && \
     cd "dnsdist-${DNSDIST_VERSION}" && \

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -40,8 +40,8 @@ RUN apk upgrade --no-cache && \
 
 ENV PAGER less
 
-RUN addgroup -S dnsdist && \
-    adduser -S -D -G dnsdist dnsdist
+RUN addgroup -g 1000 -S dnsdist && \
+    adduser -u 1000 -G dnsdist -S -D -H dnsdist
 
 COPY --from=builder /usr/local/bin /usr/local/bin/
 COPY --from=builder /usr/share/man/man1 /usr/share/man/man1/

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --update upgrade && \
     apk add --virtual .build-depends \
       file gnupg g++ make \
       boost-dev openssl-dev libsodium-dev lua-dev net-snmp-dev protobuf-dev \
-      libedit-dev re2-dev && \
+      libedit-dev re2-dev h2o-dev && \
     [ -n "$DNSDIST_VERSION" ] || { curl -sSL 'https://api.github.com/repos/PowerDNS/pdns/tags?per_page=100&page={1,2,3}' | jq -rs '[.[][]]|map(select(has("name")))|map(select(.name|contains("dnsdist-")))|map(.version=(.name|ltrimstr("dnsdist-")))|map(select(true != (.version|contains("-"))))|map(.version)|"DNSDIST_VERSION="+.[0]' > /tmp/latest-dnsdist-tag.sh && . /tmp/latest-dnsdist-tag.sh; } && \
     mkdir -v -m 0700 -p /root/.gnupg && \
     curl -RL -O 'https://dnsdist.org/_static/dnsdist-keyblock.asc' && \
@@ -22,7 +22,7 @@ RUN apk --update upgrade && \
     ( \
         cd "dnsdist-${DNSDIST_VERSION}" && \
         ./configure --sysconfdir=/etc/dnsdist --mandir=/usr/share/man \
-            --enable-dnscrypt --enable-dns-over-tls --with-libsodium --with-re2 --with-net-snmp && \
+            --enable-dnscrypt --enable-dns-over-tls --enable-dns-over-https --with-libsodium --with-re2 --with-net-snmp && \
         make -j 2 && \
         make install-strip \
     ) && \
@@ -34,7 +34,7 @@ LABEL maintainer="https://keybase.io/tcely"
 RUN apk --update upgrade && \
     apk add ca-certificates curl less mdocml \
         openssl libsodium lua net-snmp protobuf \
-        libedit re2 && \
+        libedit re2 h2o && \
     rm -rf /var/cache/apk/*
 
 ENV PAGER less

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -2,40 +2,41 @@ FROM alpine:3 AS builder
 
 ARG DNSDIST_VERSION
 
-RUN apk --update upgrade && \
-    apk add ca-certificates curl jq && \
-    apk add --virtual .build-depends \
-      file gnupg g++ make \
-      boost-dev openssl-dev libsodium-dev lua-dev net-snmp-dev protobuf-dev \
-      libedit-dev re2-dev h2o-dev && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
+        ca-certificates curl jq \
+        file gnupg g++ make \
+        boost-dev openssl-dev libsodium-dev lua-dev net-snmp-dev protobuf-dev \
+        libedit-dev re2-dev h2o-dev && \
     [ -n "$DNSDIST_VERSION" ] || { curl -sSL 'https://api.github.com/repos/PowerDNS/pdns/tags?per_page=100&page={1,2,3}' | jq -rs '[.[][]]|map(select(has("name")))|map(select(.name|contains("dnsdist-")))|map(.version=(.name|ltrimstr("dnsdist-")))|map(select(true != (.version|contains("-"))))|map(.version)|"DNSDIST_VERSION="+.[0]' > /tmp/latest-dnsdist-tag.sh && . /tmp/latest-dnsdist-tag.sh; } && \
     mkdir -v -m 0700 -p /root/.gnupg && \
     curl -RL -O 'https://dnsdist.org/_static/dnsdist-keyblock.asc' && \
-    gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true \
-        --import *.asc && \
+    gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true --import *.asc && \
     curl -RL -O "https://downloads.powerdns.com/releases/dnsdist-${DNSDIST_VERSION}.tar.bz2{.asc,.sig,}" && \
-    gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true \
-        --verify *.sig && \
-    rm -rf /root/.gnupg *.asc *.sig && \
+    gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true --verify *.sig && \
     tar -xpf "dnsdist-${DNSDIST_VERSION}.tar.bz2" && \
-    rm -f "dnsdist-${DNSDIST_VERSION}.tar.bz2" && \
-    ( \
-        cd "dnsdist-${DNSDIST_VERSION}" && \
-        ./configure --sysconfdir=/etc/dnsdist --mandir=/usr/share/man \
-            --enable-dnscrypt --enable-dns-over-tls --enable-dns-over-https --with-libsodium --with-re2 --with-net-snmp && \
-        make -j 2 && \
-        make install-strip \
-    ) && \
-    apk del --purge .build-depends && rm -rf /var/cache/apk/*
+    cd "dnsdist-${DNSDIST_VERSION}" && \
+    ./configure \
+        --sysconfdir=/etc/dnsdist \
+        --mandir=/usr/share/man \
+        --enable-dnscrypt \
+        --enable-dns-over-tls \
+        --enable-dns-over-https \
+        --with-libsodium \
+        --with-re2 \
+        --with-net-snmp && \
+    make -j 2 && \
+    make install-strip
+
 
 FROM alpine:3
 LABEL maintainer="https://keybase.io/tcely"
 
-RUN apk --update upgrade && \
-    apk add ca-certificates curl less mdocml \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
+        ca-certificates curl less mdocml \
         openssl libsodium lua net-snmp protobuf \
-        libedit re2 h2o && \
-    rm -rf /var/cache/apk/*
+        libedit re2 h2o
 
 ENV PAGER less
 

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -9,11 +9,10 @@ RUN apk upgrade --no-cache && \
         boost-dev openssl-dev libsodium-dev lua-dev net-snmp-dev protobuf-dev \
         libedit-dev re2-dev h2o-dev && \
     [ -n "$DNSDIST_VERSION" ] || { curl -sSL 'https://api.github.com/repos/PowerDNS/pdns/tags?per_page=100&page={1,2,3}' | jq -rs '[.[][]]|map(select(has("name")))|map(select(.name|contains("dnsdist-")))|map(.version=(.name|ltrimstr("dnsdist-")))|map(select(true != (.version|contains("-"))))|map(.version)|"DNSDIST_VERSION="+.[0]' > /tmp/latest-dnsdist-tag.sh && . /tmp/latest-dnsdist-tag.sh; } && \
-    mkdir -v -m 0700 -p /root/.gnupg && \
     curl -sSRL -O 'https://dnsdist.org/_static/dnsdist-keyblock.asc' && \
-    gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true --import *.asc && \
+    gpg --import *.asc && \
     curl -sSRL -O "https://downloads.powerdns.com/releases/dnsdist-${DNSDIST_VERSION}.tar.bz2{.asc,.sig,}" && \
-    gpg2 --no-options --verbose --keyid-format 0xlong --keyserver-options auto-key-retrieve=true --verify *.sig && \
+    gpg --verify *.sig && \
     tar -xpf "dnsdist-${DNSDIST_VERSION}.tar.bz2" && \
     cd "dnsdist-${DNSDIST_VERSION}" && \
     ./configure \

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -39,9 +39,6 @@ RUN apk upgrade --no-cache && \
 
 ENV PAGER less
 
-RUN addgroup -g 1000 -S dnsdist && \
-    adduser -u 1000 -G dnsdist -S -D -H dnsdist
-
 COPY --from=builder /usr/local/bin /usr/local/bin/
 COPY --from=builder /usr/share/man/man1 /usr/share/man/man1/
 


### PR DESCRIPTION
Closes #16.

### Key changes:
* Enabled DoH support
* Improved readability
* Disabled GPG key auto-retrieval
* ~Set explicit UID/GID~ Removed dnsdist user/group creation

### Compatibility issue:
~The current explicit UID/GID (1000:1000) differs from the default one (101:101), which will cause permission issues for people running the non-root user (which is not a default behavior - affected user base is minimal). However, using implicit UID/GIDs is not reliable in the first place, so I suppose the change does more good than harm.~

No longer related, read the comment below.