### PR TITLE
authoritative: add missing lmdb dependency

### DIFF
--- a/authoritative/Dockerfile
+++ b/authoritative/Dockerfile
@@ -40,7 +40,7 @@ ARG LUA_VERSION
 
 RUN apk --update upgrade && \
     apk add ca-certificates curl less mandoc \
-        boost-program_options \
+        boost-program_options boost-serialization \
         openssl libsodium lmdb lua${LUA_VERSION}-libs net-snmp protobuf \
         mariadb-connector-c libpq sqlite-libs \
         geoip yaml-cpp && \


### PR DESCRIPTION
The image currently is missing the boost-serialization library needed by the lmdb backend. Enabling it throws the following error:

```
Unable to load module '/usr/local/lib/pdns/liblmdbbackend.so': Error loading shared library libboost_serialization.so.1.80.0: No such file or directory (needed by /usr/local/lib/pdns/liblmdbbackend.so)
```